### PR TITLE
Html snippets

### DIFF
--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -1,6 +1,8 @@
 fs = require 'fs'
 
 module.exports = (grunt)->
+  snippets = grunt.file.read snippetPath for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
+  # TODO resolve snippet filename conflicts by scoping to module folders
 
   grunt.loadNpmTasks "grunt-extend-config"
 
@@ -9,7 +11,7 @@ module.exports = (grunt)->
       app:
         expand: true
         cwd: 'app'
-        src: ['*/views/**/*.html', '!**/layout.*', '!**/*.android.html']
+        src: ['*/views/**/*.html', '!**/layout.*', '!**/*.android.html', '!**/snippets/**/*.html']
         dest: 'dist/app/'
   }
 
@@ -51,7 +53,8 @@ module.exports = (grunt)->
         viewName: context.view
         moduleName: context.module
         modules: context.modules
-        snippets: context.snippets
+        snippets
+        # snippets: getSnippets()
     }
 
   determineDestinationLayoutAndSource = (destination, source, layoutPaths) ->

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -39,6 +39,7 @@ module.exports = (grunt)->
       view
       module
       modules: discoverModuleDependencies module
+      snippets: # TODO
     }
 
   toAndroidFilepath = (filepath) -> filepath.replace /(\.android)?\.html$/, '.android.html'
@@ -50,6 +51,7 @@ module.exports = (grunt)->
         viewName: context.view
         moduleName: context.module
         modules: context.modules
+        snippets: context.snippets
     }
 
   determineDestinationLayoutAndSource = (destination, source, layoutPaths) ->

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -14,8 +14,6 @@ module.exports = (grunt)->
       grunt.file.read snippetPath
     )
 
-  # TODO resolve snippet filename conflicts by scoping to module folders
-
   grunt.loadNpmTasks "grunt-extend-config"
 
   grunt.extendConfig {
@@ -70,7 +68,6 @@ module.exports = (grunt)->
         moduleName: context.module
         modules: context.modules
         snippets: snippets
-        # snippets: getSnippets()
     }
 
   determineDestinationLayoutAndSource = (destination, source, layoutPaths) ->

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -11,7 +11,7 @@ module.exports = (grunt)->
       app:
         expand: true
         cwd: 'app'
-        src: ['*/views/**/*.html', '!**/layout.*', '!**/*.android.html', '!**/snippets/**/*.html']
+        src: ['*/views/**/*.html', '!**/layout.*', '!**/*.android.html', '!*/snippets/**/*.html']
         dest: 'dist/app/'
   }
 

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -1,7 +1,7 @@
 fs = require 'fs'
 
 module.exports = (grunt)->
-  snippets = grunt.file.read snippetPath for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
+  snippets = (grunt.file.read snippetPath for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html'])
   # TODO resolve snippet filename conflicts by scoping to module folders
 
   grunt.loadNpmTasks "grunt-extend-config"
@@ -41,7 +41,6 @@ module.exports = (grunt)->
       view
       module
       modules: discoverModuleDependencies module
-      snippets: # TODO
     }
 
   toAndroidFilepath = (filepath) -> filepath.replace /(\.android)?\.html$/, '.android.html'
@@ -101,4 +100,3 @@ module.exports = (grunt)->
             "app/#{context.module}/views/layout.html"
             "app/common/views/layout.html"
           ]
-

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -4,14 +4,15 @@ module.exports = (grunt)->
   snippets = {}
   addToObj = (obj, key, value) -> obj[key] = value
 
-  addToObj(
-    snippets
-    snippetPath.substring(
-      snippetPath.lastIndexOf('/') + 1
-      snippetPath.lastIndexOf '.'
+  for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
+    addToObj(
+      snippets
+      snippetPath.substring(
+        snippetPath.lastIndexOf('/') + 1
+        snippetPath.lastIndexOf '.'
+      )
+      grunt.file.read snippetPath
     )
-    grunt.file.read snippetPath
-  ) for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
 
   # TODO resolve snippet filename conflicts by scoping to module folders
 
@@ -94,7 +95,11 @@ module.exports = (grunt)->
 
   maybeRenderWithLayouts = (source, destination, context, layoutPaths) ->
     for destinationPath, {sourcePath, layoutPath} of determineDestinationLayoutAndSource(destination, source, layoutPaths)
-      content = grunt.file.read sourcePath
+      content = grunt.util._.template(grunt.file.read sourcePath) {
+        yield:
+          snippets: snippets
+      }
+
       if layoutPath?
         grunt.file.write destinationPath, (renderWithLayout layoutPath, content, context)
       else

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -15,7 +15,12 @@ module.exports = (grunt)->
       app:
         expand: true
         cwd: 'app'
-        src: ['*/views/**/*.html', '!**/layout.*', '!**/*.android.html', '!*/snippets/**/*.html']
+        src: [
+          '*/views/**/*.html'
+          '!**/layout.*'
+          '!**/*.android.html'
+          '!*/snippets/**/*.html'
+        ]
         dest: 'dist/app/'
   }
 
@@ -56,7 +61,7 @@ module.exports = (grunt)->
         viewName: context.view
         moduleName: context.module
         modules: context.modules
-        snippets
+        snippets: snippets
         # snippets: getSnippets()
     }
 

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -4,7 +4,14 @@ module.exports = (grunt)->
   snippets = {}
   addToObj = (obj, key, value) -> obj[key] = value
 
-  addToObj snippets (snippetPath.substring (snippetPath.lastIndexOf '/') (snippetPath.lastIndexOf '.')) (grunt.file.read snippetPath) for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
+  addToObj(
+    snippets
+    snippetPath.substring(
+      snippetPath.lastIndexOf('/') + 1
+      snippetPath.lastIndexOf '.'
+    )
+    grunt.file.read snippetPath
+  ) for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
 
   # TODO resolve snippet filename conflicts by scoping to module folders
 

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -1,7 +1,11 @@
 fs = require 'fs'
 
 module.exports = (grunt)->
-  snippets = (grunt.file.read snippetPath for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html'])
+  snippets = {}
+  addToObj = (obj, key, value) -> obj[key] = value
+
+  addToObj snippets (snippetPath.substring (snippetPath.lastIndexOf '/') (snippetPath.lastIndexOf '.')) (grunt.file.read snippetPath) for snippetPath in grunt.file.expand ['app/**/snippets/**/*.html']
+
   # TODO resolve snippet filename conflicts by scoping to module folders
 
   grunt.loadNpmTasks "grunt-extend-config"

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -27,7 +27,7 @@ module.exports = (grunt)->
           '*/views/**/*.html'
           '!**/layout.*'
           '!**/*.android.html'
-          '!*/snippets/**/*.html'
+          '!**/snippets/**/*.html'
         ]
         dest: 'dist/app/'
   }


### PR DESCRIPTION
As discussed in [this forum thread](https://forums.appgyver.com/#!/steroids:is-there-a-better-way-to-ma), new functionality to support html 'snippets'.

To use the new functionality, create a new snippets folder in `app/common`, and put your snippet html files in there. Inject any of your snippets by using `<%= yield.snippets['your-snippet-filename'] %>` (don't include ‘.html’ in the filename here!).

It also works with putting snippets in any of your module folders (under a `snippets` directory there). What I don't think will work is putting snippets inside snippets, i.e. nesting.
