### PR TITLE
Move peer dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
     "chalk": "0.3.0",
     "lodash": "2.4.1",
     "wrench": "1.5.4",
-    "xml2js": "0.4.4"
-  },
-  "peerDependencies": {
-    "grunt": "0.4.5",
+    "xml2js": "0.4.4",
     "grunt-contrib-copy": "0.7.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-coffee": "0.12.0",
     "grunt-contrib-sass": "0.8.1",
     "grunt-extend-config": "0.9.2"
+  },
+  "peerDependencies": {
+    "grunt": "0.4.5"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Just a quick fix to close #15

You have a weird little setup over here :see_no_evil: :hear_no_evil: :speak_no_evil:

Still wondering why there is no `grunt-contrib-nodeunit` in the `package.json`.
Because you seem to use it in the Gruntfile:
https://github.com/AppGyver/grunt-steroids/blob/master/Gruntfile.js#L30