### PR TITLE
View fragments in nested subdirectories are now recognised and not rendered with layout

### DIFF
--- a/tasks/fresh/modules/steroids-module-compile-views-cordova.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views-cordova.coffee
@@ -1,0 +1,99 @@
+fs = require 'fs'
+
+module.exports = (grunt)->
+
+  grunt.loadNpmTasks "grunt-extend-config"
+  
+  grunt.extendConfig {
+    "steroids-module-compile-views-cordova":
+      app:
+        expand: true
+        cwd: 'app'
+        src: ['*/views/**/*.html', '!**/layout_cordova.*', '!**/*.android.html']
+        dest: 'dist/app/'
+  }
+
+  firstExistingFile = (files) ->
+    for file in files
+      if fs.existsSync file
+        return file
+
+  # Files starting with _ are used as view fragments and are not standalone views
+  isFragment = (filename) ->
+    (filename.indexOf '_') is 0 or /_[^\/]*?$/.test(filename)
+
+  # List of modules that this module depends on - used for including JS files
+  discoverModuleDependencies = (moduleName) ->
+    switch moduleName
+      when 'common' then ['common']
+      else ['common', moduleName]
+
+  extractContextFromFilepath = (filepath) ->
+    [
+      whole
+      module
+      view
+    ] = filepath.match /app\/([^\/]*)\/views\/([^.]*)/
+
+    {
+      view
+      module
+      modules: discoverModuleDependencies module
+    }
+
+  toAndroidFilepath = (filepath) -> filepath.replace /(\.android)?\.html$/, '.android.html'
+
+  renderWithLayout = (layoutPath, content, context) ->
+    grunt.util._.template(grunt.file.read layoutPath) {
+      yield:
+        view: content
+        viewName: context.view
+        moduleName: context.module
+        modules: context.modules
+    }
+
+  determineDestinationLayoutAndSource = (destination, source, layoutPaths) ->
+    destinations = {}
+
+    # Plain version
+    destinations[destination] =
+      sourcePath: source
+      layoutPath: firstExistingFile layoutPaths
+
+    # Android version
+    androidSource = toAndroidFilepath source
+    androidLayoutPath = firstExistingFile layoutPaths.map toAndroidFilepath
+    hasAndroidSource = fs.existsSync androidSource
+    hasAndroidLayout = !!androidLayoutPath
+    if hasAndroidSource or hasAndroidLayout
+      destinations[toAndroidFilepath destination] =
+        sourcePath: if hasAndroidSource then androidSource else source
+        layoutPath: if hasAndroidLayout then androidLayoutPath else destinations[destination].layoutPath
+
+    destinations
+
+  maybeRenderWithLayouts = (source, destination, context, layoutPaths) ->
+    for destinationPath, {sourcePath, layoutPath} of determineDestinationLayoutAndSource(destination, source, layoutPaths)
+      content = grunt.file.read sourcePath
+      if layoutPath?
+        grunt.file.write destinationPath, (renderWithLayout layoutPath, content, context)
+      else
+        grunt.file.write destinationPath, content
+
+  grunt.registerMultiTask "steroids-module-compile-views-cordova", "Compile views from app/*/views/ to dist/*", ->
+    layouts = {}
+
+    @files.forEach (file) ->
+      destination = file.dest.replace /views\//, ''
+      context = extractContextFromFilepath file.dest
+
+      for source in file.src
+        # Skip layouting if it's a _fragment
+        if isFragment context.view
+          grunt.file.copy source, destination
+        else
+          maybeRenderWithLayouts source, destination, context, [
+            "app/#{context.module}/views/layout_cordova.html"
+            "app/common/views/layout_cordova.html"
+          ]
+

--- a/tasks/fresh/modules/steroids-module-compile-views.coffee
+++ b/tasks/fresh/modules/steroids-module-compile-views.coffee
@@ -20,7 +20,7 @@ module.exports = (grunt)->
 
   # Files starting with _ are used as view fragments and are not standalone views
   isFragment = (filename) ->
-    (filename.indexOf '_') is 0
+    (filename.indexOf '_') is 0 or /_[^\/]*?$/.test(filename)
 
   # List of modules that this module depends on - used for including JS files
   discoverModuleDependencies = (moduleName) ->

--- a/tasks/fresh/steroids-clean-www.coffee
+++ b/tasks/fresh/steroids-clean-www.coffee
@@ -1,0 +1,15 @@
+
+module.exports = (grunt)->
+
+  grunt.loadNpmTasks "grunt-contrib-clean"
+  grunt.loadNpmTasks "grunt-extend-config"
+
+  grunt.registerTask "steroids-clean-www", "Clean cordova/www/", ->
+
+    grunt.extendConfig
+      clean:
+        # Clean cordova/www/ folder (delete and create again)
+        www:
+          ["cordova/www/"]
+
+    grunt.task.run "clean:www"

--- a/tasks/fresh/steroids-compile-modules-cordova.coffee
+++ b/tasks/fresh/steroids-compile-modules-cordova.coffee
@@ -1,0 +1,11 @@
+module.exports = (grunt) ->
+
+  grunt.loadTasks("#{__dirname}/modules")
+
+  grunt.registerTask "steroids-compile-modules-cordova", "Compile modules in app/ to device-ready files", [
+    'steroids-module-copy-assets'
+    'steroids-module-compile-views-cordova'
+    'steroids-module-compile-scripts'
+    'steroids-module-copy-default-native-styles'
+    'steroids-module-compile-default-native-styles'
+  ]

--- a/tasks/fresh/steroids-copy-dist.coffee
+++ b/tasks/fresh/steroids-copy-dist.coffee
@@ -4,14 +4,14 @@ module.exports = (grunt)->
   grunt.loadNpmTasks "grunt-contrib-copy"
   grunt.loadNpmTasks "grunt-extend-config"
 
-  grunt.registerTask "steroids-copy-www", "Copy files from www/ to dist/ (except for .scss and .coffee) (for SPA projects)", ->
+  grunt.registerTask "steroids-copy-dist", "Copy files from dist/ to www/ (except for .scss and .coffee) (for SPA projects)", ->
 
     grunt.extendConfig
       copy:
-        www:
+        dist:
           expand:true
-          cwd: 'www/'
+          cwd: 'dist/'
           src: ['**/*.*', '!**/*.coffee', '!**/*.scss']
-          dest: 'dist/'
+          dest: 'cordova/www/'
 
-    grunt.task.run "copy:www"
+    grunt.task.run "copy:dist"

--- a/tasks/fresh/steroids-setup-features-cordova.coffee
+++ b/tasks/fresh/steroids-setup-features-cordova.coffee
@@ -1,0 +1,23 @@
+features = require '../../lib/features'
+
+module.exports = (grunt) ->
+
+  grunt.loadNpmTasks "grunt-extend-config"
+
+  # KLUDGE: toggling AutoHideSplashScreen is disabled in supersonic until native gets a smarter autohide
+  grunt.extendConfig {
+    'steroids-setup-features-cordova':
+      dist:
+        src: 'dist/**/*.html'
+  }
+  grunt.registerMultiTask 'steroids-setup-features-cordova', ->
+    count = 0
+    @files.forEach (pair) ->
+      pair.src.forEach (src) ->
+        grunt.file.copy src, src,
+          process: (contents) ->
+            contents.replace /"\/icons/g, """
+            	\"../../icons
+            """
+        count++
+    grunt.log.ok "Processed #{count} files"

--- a/tasks/fresh/steroids-setup-features-cordova.coffee
+++ b/tasks/fresh/steroids-setup-features-cordova.coffee
@@ -16,8 +16,24 @@ module.exports = (grunt) ->
       pair.src.forEach (src) ->
         grunt.file.copy src, src,
           process: (contents) ->
-            contents.replace /"\/icons/g, """
-            	\"../../icons
-            """
+            contents.replace /"\/app/g, """\"../../app"""
+        count++
+    @files.forEach (pair) ->
+      pair.src.forEach (src) ->
+        grunt.file.copy src, src,
+          process: (contents) ->
+            contents.replace /\=\/app/g, '=../../app'
+        count++
+    @files.forEach (pair) ->
+      pair.src.forEach (src) ->
+        grunt.file.copy src, src,
+          process: (contents) ->
+            contents.replace /"\/components/g, """\"../../components"""
+        count++
+    @files.forEach (pair) ->
+      pair.src.forEach (src) ->
+        grunt.file.copy src, src,
+          process: (contents) ->
+            contents.replace /"\/icons/g, '"../../icons'
         count++
     grunt.log.ok "Processed #{count} files"

--- a/tasks/fresh/steroids-setup-features-cordova.coffee
+++ b/tasks/fresh/steroids-setup-features-cordova.coffee
@@ -16,18 +16,6 @@ module.exports = (grunt) ->
       pair.src.forEach (src) ->
         grunt.file.copy src, src,
           process: (contents) ->
-            contents.replace /"\/app/g, """\"../../app"""
-        count++
-    @files.forEach (pair) ->
-      pair.src.forEach (src) ->
-        grunt.file.copy src, src,
-          process: (contents) ->
-            contents.replace /\=\/app/g, '=../../app'
-        count++
-    @files.forEach (pair) ->
-      pair.src.forEach (src) ->
-        grunt.file.copy src, src,
-          process: (contents) ->
             contents.replace /"\/components/g, """\"../../components"""
         count++
     @files.forEach (pair) ->

--- a/tasks/steroids-make-fresh-cordova.coffee
+++ b/tasks/steroids-make-fresh-cordova.coffee
@@ -4,7 +4,7 @@ module.exports = (grunt) ->
     grunt.task.run [
       "steroids-check-project"
       "steroids-clean-dist"
-      "steroids-copy-www"
+      "steroids-clean-www"
       "steroids-compile-coffee"
       "steroids-copy-components"
       "steroids-configure"
@@ -12,4 +12,5 @@ module.exports = (grunt) ->
       "steroids-compile-sass"
       "steroids-copy-css"
       "steroids-setup-features-cordova"
+      "steroids-copy-dist"
     ]

--- a/tasks/steroids-make-fresh-cordova.coffee
+++ b/tasks/steroids-make-fresh-cordova.coffee
@@ -1,0 +1,15 @@
+module.exports = (grunt) ->
+  grunt.registerTask "steroids-make-fresh-cordova", "Create the dist/ folder that is copied to the device.", ->
+    grunt.loadTasks("#{__dirname}/fresh")
+    grunt.task.run [
+      "steroids-check-project"
+      "steroids-clean-dist"
+      "steroids-copy-www"
+      "steroids-compile-coffee"
+      "steroids-copy-components"
+      "steroids-configure"
+      "steroids-compile-modules-cordova"
+      "steroids-compile-sass"
+      "steroids-copy-css"
+      "steroids-setup-features-cordova"
+    ]

--- a/tasks/steroids-make-fresh.coffee
+++ b/tasks/steroids-make-fresh.coffee
@@ -4,7 +4,6 @@ module.exports = (grunt) ->
     grunt.task.run [
       "steroids-check-project"
       "steroids-clean-dist"
-      "steroids-copy-www"
       "steroids-compile-coffee"
       "steroids-copy-components"
       "steroids-configure"


### PR DESCRIPTION
We are using subdirectories for our views to help manage a large application. Currently only templates prefixed with '_' are not being rendered with layout.
This change makes it so that nested fragments can also not be rendered with layout.
